### PR TITLE
Replace directory substitution plugin with condition_script_runner_args

### DIFF
--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -95,28 +95,6 @@ if not is_empty ${script_output}
 end
 '''
 
-# This plugin replaces the embedded `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY` in the rust-script doc comment with its evaluated value. See https://github.com/sagiegurari/cargo-make/issues/1081 for more context.
-[plugins.impl.rust-condition-script-cargo_make_current_task_initial_makefile_directory-substitution]
-script = '''
-# Parse task json into variables
-taskjson = json_parse ${task.as_json}
-
-# Convert backslashes to forward slashes
-rust-driver-toolchain-path = replace ${taskjson.env.CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY} "\\" "/"
-
-# Replace the ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY} variable in the condition_script with the rust-driver-toolchain-path
-taskjson.condition_script = replace ${taskjson.condition_script} "\${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}" "${rust-driver-toolchain-path}"
-
-# Unset the private flag since it breaks cm_plugin_run_custom_task: https://github.com/sagiegurari/cargo-make/issues/1084
-unset taskjson.private
-
-# Reencode variables into json
-taskjson = json_encode taskjson
-
-# Run the invoking task, with the modified condition_script
-cm_plugin_run_custom_task ${taskjson}
-'''
-
 # This plugin adds support for cargo-make's emulated workspace feature to work on emulated workspace members which are Cargo workspaces themselves.
 # Since Cargo workspaces are not detected in cargo-make emulated workspace members, the task is rerun in a forked subprocess with the CARGO_MAKE_CRATE_CURRENT_WORKSPACE_MEMBER env var unset to allow cargo-make's workspace detection to run.
 [plugins.impl.nested-cargo-workspace-in-cargo-make-emulated-workspace-support]
@@ -237,13 +215,16 @@ std::fs::copy(&source_file, &destination_file).expect(&format!(
 [tasks.generate-driver-binary-file]
 private = true
 dependencies = ["setup-wdk-config-env-vars", "build"]
-plugin = "rust-condition-script-cargo_make_current_task_initial_makefile_directory-substitution"
+condition_script_runner_args = [
+  "--base-path",
+  "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}",
+]
 condition_script = '''
 #!@rust
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.2.0" }
 //! ```
 #![allow(unused_doc_comments)]
 

--- a/crates/wdk-build/rust-driver-sample-makefile.toml
+++ b/crates/wdk-build/rust-driver-sample-makefile.toml
@@ -28,13 +28,16 @@ wdk_build::cargo_make::forward_printed_env_vars(
 
 [tasks.infverif]
 dependencies = ["wdk-samples-setup", "stampinf"]
-plugin = "rust-condition-script-cargo_make_current_task_initial_makefile_directory-substitution"
+condition_script_runner_args = [
+  "--base-path",
+  "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}",
+]
 condition_script = '''
 #!@rust
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.2.0" }
 //! ```
 #![allow(unused_doc_comments)]
 


### PR DESCRIPTION
With the recent merge of [Expand condition_script_runner_args](https://github.com/sagiegurari/cargo-make/pull/1132) the `[plugins.impl.rust-condition-script-cargo_make_current_task_initial_makefile_directory-substitution]` plugin is no longer needed. The new feature `condition_script_runner_args` allows directly passing base path to the condition script runner.